### PR TITLE
[BOAT] Snipe upgrades

### DIFF
--- a/boat/commands/snipe.js
+++ b/boat/commands/snipe.js
@@ -47,7 +47,7 @@ module.exports = function (msg) {
 
     length += name.length + snipe.msg.length
     fields[cursor].push({
-      name: `${snipe.author} (${snipe.type})`,
+      name: `${snipe.author} (${snipe.type}) in #${snipe.channel}`,
       value: snipe.msg.slice(0, 1024)
     })
 

--- a/boat/sniper.js
+++ b/boat/sniper.js
@@ -37,7 +37,7 @@ module.exports = {
     })
 
     bot.on('messageUpdate', (msg, old) => {
-      if (!old || !msg.author || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot) {
+      if (!old || !msg.author || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot || msg.content === old.content) {
         return // Let's ignore
       }
 
@@ -51,6 +51,7 @@ module.exports = {
       _id: id,
       author: `${msg.author.username}#${msg.author.discriminator}`,
       msg: msg.content.replace(/\(/g, `${zws}(`),
+      channel: msg.channel.name,
       type
     })
 


### PR DESCRIPTION
This commit does two things.
1. Doesn't snipe edited messages that have the same content as the original (usually caused by embeds)
2. Adds the channel the sniped message was sent in to the header. Useful for when people post in #plugin-links and you snipe in #off-topic. (channel name isnt a channel mention because you cant have mentions in embed field titles for some reason)