### PR TITLE
[BOAT] Auto Tags

### DIFF
--- a/boat/autotag.js
+++ b/boat/autotag.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018-2020 aetheryx & Bowser65
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const config = require('../config.json')
+
+module.exports = {
+  async regester (bot) {
+    bot.on('messageCreate', (msg) => this.process(msg))
+  },
+
+  async process (msg) {
+    if (!msg.content.startsWith(config.discord.prefix)) {
+      return
+    }
+
+    const command = msg.content.slice(config.discord.prefix.length, msg.content.length).toLowerCase()
+    const tags = await msg._client.mongo.collection('tags').find().toArray()
+
+    tags.forEach(tag => {
+      if (tag._id.toLowerCase() === command) {
+        return msg.channel.createMessage(tag.content)
+      }
+    })
+  }
+}

--- a/boat/autotag.js
+++ b/boat/autotag.js
@@ -23,7 +23,7 @@
 const config = require('../config.json')
 
 module.exports = {
-  async register (bot) {
+  register (bot) {
     bot.on('messageCreate', (msg) => this.process(msg))
   },
 

--- a/boat/autotag.js
+++ b/boat/autotag.js
@@ -23,7 +23,7 @@
 const config = require('../config.json')
 
 module.exports = {
-  async regester (bot) {
+  async register (bot) {
     bot.on('messageCreate', (msg) => this.process(msg))
   },
 

--- a/boat/index.js
+++ b/boat/index.js
@@ -66,7 +66,7 @@ roles.register(bot)
 canary.register(bot)
 starboard.register(bot)
 stats.register(bot)
-autotag.regester(bot)
+autotag.register(bot)
 
 // Events
 bot.on('ready', () => console.log('Ready.'))

--- a/boat/index.js
+++ b/boat/index.js
@@ -32,6 +32,7 @@ const starboard = require('./starboard')
 const stats = require('./stats')
 const config = require('../config.json')
 const task = require('./tasks')
+const autotag = require('./autotag')
 
 const bot = new CommandClient(config.discord.botToken, {
   intents: [ 'guilds', 'guildBans', 'guildMembers', 'guildPresences', 'guildMessages', 'guildMessageReactions' ]
@@ -65,6 +66,7 @@ roles.register(bot)
 canary.register(bot)
 starboard.register(bot)
 stats.register(bot)
+autotag.regester(bot)
 
 // Events
 bot.on('ready', () => console.log('Ready.'))


### PR DESCRIPTION
This PR adds auto tags. Auto tags allow for tags to be viewed without the word `tag` in front of the tag name. For example, if I wanted to call up the pysucks tag, I could use `pc/tag pysucks` or I could just use `pc/pysucks`. Auto tags use the same database format as normal tags and as such, all normal tags are auto tags. 