### PR TITLE
[BOAT] Starboard now takes all star types

### DIFF
--- a/boat/starboard.js
+++ b/boat/starboard.js
@@ -24,7 +24,7 @@ const config = require('../config.json')
 
 const BOARD_MINIMUM = 3
 const CUTEBOARD_EMOTE = '🌺'
-const STARBOARD_EMOTE = '⭐'
+const STARBOARD_EMOTE = [ '⭐', '🌟', '💫', '✨' ]
 const GENERIC_STAR_OBJ = {
   messageId: null,
   stars: 0
@@ -51,8 +51,8 @@ module.exports = {
     }
 
     const filter = u => u.id !== msg.author.id && !config.discord.ids.shitstars.users.includes(u.id)
-    if (emoji.name === STARBOARD_EMOTE && this._isProcessable(msg, user)) {
-      const reactions = await this._getAllReactions(msg, STARBOARD_EMOTE)
+    if (STARBOARD_EMOTE.includes(emoji.name) && this._isProcessable(msg, user)) {
+      const reactions = await this._getAllReactions(msg, emoji.name)
       this.updateStarCount(msg, reactions.filter(filter).length)
     }
 

--- a/boat/starboard.js
+++ b/boat/starboard.js
@@ -24,7 +24,7 @@ const config = require('../config.json')
 
 const BOARD_MINIMUM = 3
 const CUTEBOARD_EMOTE = '🌺'
-const STARBOARD_EMOTE = [ '⭐', '🌟', '💫', '✨' ]
+const STARBOARD_EMOTES = [ '⭐', '🌟', '💫', '✨' ]
 const GENERIC_STAR_OBJ = {
   messageId: null,
   stars: 0
@@ -51,7 +51,7 @@ module.exports = {
     }
 
     const filter = u => u.id !== msg.author.id && !config.discord.ids.shitstars.users.includes(u.id)
-    if (STARBOARD_EMOTE.includes(emoji.name) && this._isProcessable(msg, user)) {
+    if (STARBOARD_EMOTES.includes(emoji.name) && this._isProcessable(msg, user)) {
       const reactions = await this._getAllReactions(msg, emoji.name)
       this.updateStarCount(msg, reactions.filter(filter).length)
     }
@@ -68,7 +68,10 @@ module.exports = {
       ...GENERIC_STAR_OBJ,
       cute
     }
-    entry.stars = count
+
+    if (entry.stars < count) {
+      entry.stars = count
+    }
 
     if (entry.stars < BOARD_MINIMUM) {
       if (entry.messageId) {


### PR DESCRIPTION
This PR makes the starboard accept these four star types`⭐, 🌟, 💫, ✨`. It takes whichever one of the four has the most reactions so one person cant react to a post with three of them and then singlehandedly starboard the post.