### PR TITLE
[BOAT] [FIX] Snipe breaks when sniping an empty message

### DIFF
--- a/boat/sniper.js
+++ b/boat/sniper.js
@@ -50,7 +50,7 @@ module.exports = {
     this.lastMessages.push({
       _id: id,
       author: `${msg.author.username}#${msg.author.discriminator}`,
-      msg: msg.content.replace(/\(/g, `${zws}(`),
+      msg: msg.content ? msg.content.replace(/\(/g, `${zws}(`) : 'This message had no text content.',
       channel: msg.channel.name,
       type
     })


### PR DESCRIPTION
This PR fixes the error that occurs when someone tries to snipe an empty message (usually a file upload). Instead of doing absolutely nothing and erroring in silence, the nothingness is replaced with a message saying `This message had no text content.` Thats all it does, one line, one fix.