### PR TITLE
[BOAT] Embeds in the guidelines command

### DIFF
--- a/boat/commands/guideline.js
+++ b/boat/commands/guideline.js
@@ -36,8 +36,20 @@ module.exports = async function (msg, args) {
     const guidelines = await fetch(GUIDELINES_DOCUMENT).then(r => r.text())
 
     if (args[0] === 'defs') {
-      const defs = guidelines.split('## Definitions')[1].split('\n\n')[0].trim()
-      return msg.channel.createMessage(`**Definitions:**\n ${defs}\n\n${INFO_STR}`)
+      const defs = guidelines.split('## Definitions')[1].split('\n\n')[0].trim().split('\n')
+      const fields = []
+      defs.forEach(def => {
+        fields.push({
+          name: def.split(':')[0].replace('-', ' ').trim(),
+          value: def.split(':')[1]
+        })
+      })
+      const embed = {
+        title: 'Definitions',
+        description: INFO_STR,
+        fields
+      }
+      return msg.channel.createMessage({ embed })
     }
 
     const id = parseInt(args[0])
@@ -47,10 +59,19 @@ module.exports = async function (msg, args) {
     }
 
     const guideline = match[0].slice(2).replace(/\n\n/g, '<br><br>').split('\n')
-    guideline[0] = `**Guideline #${guideline[0]}**\n`
-    const parts = guideline.map(g => g.replace(/<br>/g, '\n'))
-    msg.channel.createMessage(`${parts.join('').trim()}\n\n${INFO_STR}`)
+    const embed = {
+      title: guideline.shift(),
+      description: guideline.map(g => g.replace(/<br>/g, '\n')).join('').trim(),
+      fields: [
+        {
+          name: 'Read all the guidelines',
+          value: 'https://powercord.dev/guidelines'
+        }
+      ]
+    }
+    msg.channel.createMessage({ embed })
   } catch (e) {
+    console.log(e)
     msg.channel.createMessage('An unexpected error occurred. Maybe GitHub is having troubles?')
   }
 }

--- a/boat/commands/guideline.js
+++ b/boat/commands/guideline.js
@@ -71,7 +71,7 @@ module.exports = async function (msg, args) {
     }
     msg.channel.createMessage({ embed })
   } catch (e) {
-    console.log(e)
+    console.error('error occurred while fetching guidelines', e)
     msg.channel.createMessage('An unexpected error occurred. Maybe GitHub is having troubles?')
   }
 }


### PR DESCRIPTION
"Why make the guidelines embeds?" you as. Simple, they look better. Also the guidelines have masked links in them and masked links work in embeds but not in regular messages so embeds are just better for this application imo. Guidelines and defs are still fetched from GitHub so stuff can be changed or added and as long as its in the same format the command should adapt just fine. The `defs` subcommand has also been made into an embed and should update with GitHub as well.