### PR TITLE
[BOAT] Sniper no longer snipes private channels

### DIFF
--- a/boat/sniper.js
+++ b/boat/sniper.js
@@ -29,7 +29,7 @@ module.exports = {
 
   register (bot) {
     bot.on('messageDelete', (msg) => {
-      if (!msg.author || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot) {
+      if (!msg.author || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot || isPrivate(msg.channel)) {
         return // Let's ignore
       }
 
@@ -37,7 +37,7 @@ module.exports = {
     })
 
     bot.on('messageUpdate', (msg, old) => {
-      if (!old || !msg.author || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot || msg.content === old.content) {
+      if (!old || !msg.author || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot || msg.content === old.content || isPrivate(msg.channel)) {
         return // Let's ignore
       }
 
@@ -57,4 +57,8 @@ module.exports = {
 
     setTimeout(() => (this.lastMessages = this.lastMessages.filter(m => m._id !== id)), this.SNIPE_LIFETIME * 1e3)
   }
+}
+
+function isPrivate(channel) {
+  return channel.permissionOverwrites.filter(overwrite => overwrite.id === channel.guild.id && !overwrite.has('readMessages')).length === 1
 }


### PR DESCRIPTION
This PR makes it no longer possible to snipe private channels. Private channels are channels where the @everyone role is denied the read messages permission. This is what determines if the channel gets the little lock icon and is also what the bot looks for when stopping the sniper. I added this detection to a function as its a rather long boolean expression. The function currently lives in the boat/sniper.js file but could be moved to boat.utils.js if other commands or functionality need to check if a channel is private.