### PR TITLE
[BOAT] Adds rule content to warning when using enforce

### DIFF
--- a/boat/commands/mod/enforce.js
+++ b/boat/commands/mod/enforce.js
@@ -73,7 +73,7 @@ async function punish (msg, target, sentence, rule) {
 
   if (sentence.includes('warning')) {
     type = 'warning'
-    reply = `<@${target}>, you have broken rule ${rule}. More serious action will be taken the next time you do so.`
+    reply = `<@${target}>, you have broken rule ${rule}. More serious action will be taken the next time you do so.\n\n**Rule ${rule}**\n${await parseRule(rule, msg)}`
   } else if (sentence.includes('mute/ban')) {
     type = 'error'
     reply = `Unable to process \`${sentence}\`, please mod manualy.`


### PR DESCRIPTION
This PR just slaps the contents of the rule being enforced onto the end of the warning message. It makes use of that lovely parse rule util function that someone wrote a while back so it will automatically update if the rules change.