### PR TITLE
[BOAT] Add roles in member log on member leave

### DIFF
--- a/boat/commands/mod/lookup.js
+++ b/boat/commands/mod/lookup.js
@@ -62,10 +62,10 @@ module.exports = async function (msg, args) {
       })
     }
   })
-
+  const roles = getMemberRoles(guild, member)
   const fields = [ {
     name: 'Roles',
-    value: getMemberRoles(guild, member).join(' ')
+    value: roles.length > 0 ? roles.join(' ') : 'None'
   } ]
 
   infractions.forEach(({ rule, count, occurances }) => {

--- a/boat/commands/mod/lookup.js
+++ b/boat/commands/mod/lookup.js
@@ -21,7 +21,7 @@
  */
 
 const config = require('../../../config.json')
-const { humanTime, plurialify } = require('../../utils')
+const { humanTime, plurialify, getMemberRoles } = require('../../utils')
 
 const USAGE_STR = `Usage: ${config.discord.prefix}lookup <mention || discord id>`
 
@@ -47,11 +47,6 @@ module.exports = async function (msg, args) {
   const joinedAt = new Date(member.joinedAt)
   const now = new Date()
 
-  const roles = []
-  guild.roles.filter(role => member.roles.includes(role.id)).forEach(role => {
-    roles.push(role.mention)
-  })
-
   const infractions = []
   await msg._client.mongo.collection('enforce').find({ userID: member.id }).forEach(function (doc) {
     const infraction = infractions.find(inf => inf.rule === doc.rule)
@@ -70,7 +65,7 @@ module.exports = async function (msg, args) {
 
   const fields = [ {
     name: 'Roles',
-    value: roles.join()
+    value: getMemberRoles(guild, member).join(' ')
   } ]
 
   infractions.forEach(({ rule, count, occurances }) => {

--- a/boat/commands/mod/lookup.js
+++ b/boat/commands/mod/lookup.js
@@ -62,7 +62,7 @@ module.exports = async function (msg, args) {
       })
     }
   })
-  const roles = getMemberRoles(guild, member)
+  const roles = getMemberRoles(guild, member).map(role => role.mention)
   const fields = [ {
     name: 'Roles',
     value: roles.length > 0 ? roles.join(' ') : 'None'

--- a/boat/memberlog.js
+++ b/boat/memberlog.js
@@ -65,7 +65,7 @@ module.exports = {
     if (member.roles?.length > 0) {
       fields.push({
         name: 'Roles',
-        value: getMemberRoles(guild, member).join(' ')
+        value: getMemberRoles(guild, member).map(role => role.mention).join(' ')
       })
     }
 

--- a/boat/memberlog.js
+++ b/boat/memberlog.js
@@ -21,7 +21,7 @@
  */
 
 const config = require('../config.json')
-const { humanTime } = require('./utils')
+const { humanTime, getMemberRoles } = require('./utils')
 
 const memberLog = config.discord.ids.channelMemberLogs
 
@@ -53,7 +53,7 @@ module.exports = {
 
   memberRemove (guild, member) {
     if (guild.id !== config.discord.ids.serverId) return
-    const now = Date.now()
+    const now = new Date()
     let description = `<@${member.id}> was not in the cache when they left`
 
     if (member.joinedAt) {
@@ -61,11 +61,21 @@ module.exports = {
       description = `<@${member.id}> was here for ${humanTime(now - joinedAt)}`
     }
 
+    const fields = []
+    if (member.roles?.length > 0) {
+      fields.push({
+        name: 'Roles',
+        value: getMemberRoles(guild, member).join(' ')
+      })
+    }
+
     const embed = {
       title: `${member.user.username}#${member.user.discriminator} just left`,
       description,
+      fields,
       color: 0xdac372,
       thumbnail: { url: member.user.avatarURL },
+      timestamp: now.toISOString(),
       footer: { text: `Discord ID: ${member.user.id}` }
     }
     this.bot.createMessage(memberLog, { embed })

--- a/boat/utils.js
+++ b/boat/utils.js
@@ -75,6 +75,14 @@ const utils = {
 
   plurialify (count, word) {
     return count === 1 ? word : `${word}s`
+  },
+
+  getMemberRoles (guild, member) {
+    const roles = []
+    guild.roles.filter(role => member.roles.includes(role.id)).forEach(role => {
+      roles.push(role.mention)
+    })
+    return roles
   }
 }
 

--- a/boat/utils.js
+++ b/boat/utils.js
@@ -78,11 +78,7 @@ const utils = {
   },
 
   getMemberRoles (guild, member) {
-    const roles = []
-    guild.roles.filter(role => member.roles.includes(role.id)).forEach(role => {
-      roles.push(role.mention)
-    })
-    return roles
+    return guild.roles.filter(role => member.roles.includes(role.id))
   }
 }
 

--- a/boat/utils.js
+++ b/boat/utils.js
@@ -78,7 +78,7 @@ const utils = {
   },
 
   getMemberRoles (guild, member) {
-    return guild.roles.filter(role => member.roles.includes(role.id))
+    return member.roles.map(id => guild.roles.get(id))
   }
 }
 


### PR DESCRIPTION
This PR adds a list of roles a user had when they left. It also adds a `getMemberRoles` util function and updates the lookup command to use the new function.