### PR TITLE
[BOAT] Auto ban muted users who have many infractions if they attempt to circumvent the mute

### DIFF
--- a/boat/src/modules/mutedban.ts
+++ b/boat/src/modules/mutedban.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2021 aetheryx & Cynthia K. Rey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { CommandClient, Guild, Member, MemberPartial } from 'eris'
+import config from '../config.js'
+import { ban } from '../mod.js';
+
+const maxInfractions = 4
+
+async function memberRemove(this: CommandClient, guild: Guild, member: Member | MemberPartial) {
+  if (guild.id !== config.discord.ids.serverId) return
+  if (!('roles' in member)) return
+  if (!member.roles.includes(config.discord.ids.roleMuted)) return
+
+  const bans = (await guild.getBans()).map(ban => ban.user.id)
+  if (bans.includes(member.id)) return
+
+  await this.mongo.collection('enforce').insertOne({
+    userID: member.id, // todo: userID -> userId
+    rule: -1,
+    mod: `${this.user.username}#${this.user.discriminator}` // todo: store id instead
+  })
+
+  const infractionCount = await this.mongo.collection('enforce').countDocuments({ userID: member.id })
+  if (infractionCount > maxInfractions) {
+    ban(guild, member.id, this.user, '[AUTOMATIC] Left while muted one too many times.')
+  }
+}
+
+export default function (bot: CommandClient) {
+  bot.on('guildMemberRemove', memberRemove)
+}

--- a/boat/src/modules/mutedban.ts
+++ b/boat/src/modules/mutedban.ts
@@ -31,7 +31,7 @@ async function memberRemove(this: CommandClient, guild: Guild, member: Member | 
   if (!('roles' in member)) return
   if (!member.roles.includes(config.discord.ids.roleMuted)) return
 
-  const bans = (await guild.getBans()).map(ban => ban.user.id)
+  const bans = await guild.getBans().then((bans) => bans.map((ban) => ban.user.id))
   if (bans.includes(member.id)) return
 
   await this.mongo.collection('enforce').insertOne({

--- a/boat/src/modules/mutedban.ts
+++ b/boat/src/modules/mutedban.ts
@@ -24,12 +24,10 @@ import type { CommandClient, Guild, Member, MemberPartial } from 'eris'
 import config from '../config.js'
 import { ban } from '../mod.js';
 
-const maxInfractions = 4
+const MAX_INFRACTIONS = 4
 
 async function memberRemove(this: CommandClient, guild: Guild, member: Member | MemberPartial) {
-  if (guild.id !== config.discord.ids.serverId) return
-  if (!('roles' in member)) return
-  if (!member.roles.includes(config.discord.ids.roleMuted)) return
+  if (guild.id !== config.discord.ids.serverId || !('roles' in member) || !member.roles.includes(config.discord.ids.roleMuted)) return
 
   const bans = (await guild.getBans()).map(ban => ban.user.id)
   if (bans.includes(member.id)) return
@@ -41,8 +39,8 @@ async function memberRemove(this: CommandClient, guild: Guild, member: Member | 
   })
 
   const infractionCount = await this.mongo.collection('enforce').countDocuments({ userID: member.id })
-  if (infractionCount > maxInfractions) {
-    ban(guild, member.id, this.user, '[AUTOMATIC] Left while muted one too many times.')
+  if (infractionCount > MAX_INFRACTIONS){
+    ban(guild, member.id, this.user, 'Left while muted one too many times.')
   }
 }
 

--- a/boat/src/modules/mutedban.ts
+++ b/boat/src/modules/mutedban.ts
@@ -21,8 +21,8 @@
  */
 
 import type { CommandClient, Guild, Member, MemberPartial } from 'eris'
+import { ban } from '../mod.js'
 import config from '../config.js'
-import { ban } from '../mod.js';
 
 const MAX_INFRACTIONS = 4
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "api:build": "tsc --build api/tsconfig.json",
     "api:start": "cross-env NODE_ENV=production node dist/api/index.js",
     "api:debug-prod": "cross-env NODE_ENV=production node --inspect-brk dist/api/index.js",
-    "bot:dev": "tsc-watch --project boat/tsconfig.json --onSuccess \"node dist/boat/index.js\"",
-    "bot:build": "tsc --build boat/tsconfig.json",
+    "bot:dev": "rm -rf dist && tsc-watch --project boat/tsconfig.json --onSuccess \"node dist/boat/index.js\"",
+    "bot:build": "rm -rf dist && tsc --build boat/tsconfig.json",
     "bot:start": "cross-env NODE_ENV=production node dist/boat/index.js",
     "build": "rm -rf dist && pnpm run web:build && pnpm run api:build && pnpm run bot:build"
   },

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "api:build": "tsc --build api/tsconfig.json",
     "api:start": "cross-env NODE_ENV=production node dist/api/index.js",
     "api:debug-prod": "cross-env NODE_ENV=production node --inspect-brk dist/api/index.js",
-    "bot:dev": "rm -rf dist && tsc-watch --project boat/tsconfig.json --onSuccess \"node dist/boat/index.js\"",
-    "bot:build": "rm -rf dist && tsc --build boat/tsconfig.json",
+    "bot:dev": "rm -rf dist/boat && tsc-watch --project boat/tsconfig.json --onSuccess \"node dist/boat/index.js\"",
+    "bot:build": "rm -rf dist/boat && tsc --build boat/tsconfig.json",
     "bot:start": "cross-env NODE_ENV=production node dist/boat/index.js",
     "build": "rm -rf dist && pnpm run web:build && pnpm run api:build && pnpm run bot:build"
   },


### PR DESCRIPTION
The title is long but descriptive. This PR will automatically ban a user if they leave while muted and have more than four rule infractions. It also adds a rule infraction every time they leave while muted under rule `-1`. That way if a user is a repeat rule breaker, they will be auto banned sooner than if they have never broken a rule. Four was arbitrarily choses as the number but it can easily be changed by changing the `maxInfractions` const at the top of boat/src/modules/mutedban.ts