### PR TITLE
[BOAT] Make bot and mongo consts not be undeclared in async evals

### DIFF
--- a/boat/src/commands/admin/eval.ts
+++ b/boat/src/commands/admin/eval.ts
@@ -42,7 +42,7 @@ export async function executor (msg: Message<GuildTextableChannel>): Promise<voi
   const start = Date.now()
 
   let js = `const bot = msg._client; const mongo = bot.mongo; ${script}`
-  if (js.includes('await')) js = `(async () => { ${script} })()`
+  if (script.includes('await')) js = `(async () => { ${js} })()`
   let result
   try {
     // eslint-disable-next-line no-eval


### PR DESCRIPTION
See this lovely discussion on our discord server for more info
https://canary.discord.com/channels/538759280057122817/755015840847364146/793918814210359338