### PR TITLE
[BOAT] Log messageDeleteBulk events and also attachments

### DIFF
--- a/boat/src/modules/logger.ts
+++ b/boat/src/modules/logger.ts
@@ -40,7 +40,7 @@ Timestamp: $time ($duration ago)
 Message contents:
 $message`
 
-async function messageDelete(this: CommandClient, msg: Message<GuildTextableChannel>) {
+async function messageDelete (this: CommandClient, msg: Message<GuildTextableChannel>) {
   if (!msg.author || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot) {
     return // Message not cached; let's just ignore
   }
@@ -60,7 +60,7 @@ async function messageDelete(this: CommandClient, msg: Message<GuildTextableChan
   })
 }
 
-async function messageDeleteBulk(this: CommandClient, msgs: Array<Message<GuildTextableChannel> | MessagePartial>) {
+async function messageDeleteBulk (this: CommandClient, msgs: Array<Message<GuildTextableChannel> | MessagePartial>) {
   const list = msgs.map(msg => {
     if ('author' in msg) {
       return `${LIST_TEMPLATE

--- a/boat/src/modules/logger.ts
+++ b/boat/src/modules/logger.ts
@@ -22,35 +22,68 @@
 
 import type { CommandClient, GuildTextableChannel, Message } from 'eris'
 import { prettyPrintTimeSpan, stringifyDiscordMessage } from '../util.js'
+import fetch from 'node-fetch'
 import config from '../config.js'
 
+type MessagePartial = { id: string, channel: GuildTextableChannel }
+
 const ZWS = '\u200B'
-const TEMPLATE = `Message deleted in <#$channelId>
+const SINGLE_TEMPLATE = `Message deleted in <#$channelId>
 Author: $username#$discrim ($userId; <@$userId>)
 Timestamp: $time ($duration ago)
 Message contents: \`\`\`
 $message
 \`\`\``
+const LIST_TEMPLATE = `Message deleted in #$channel
+Author: $username#$discrim ($userId)
+Timestamp: $time ($duration ago)
+Message contents:
+$message`
 
-async function process (this: CommandClient, msg: Message<GuildTextableChannel>) {
+async function messageDelete(this: CommandClient, msg: Message<GuildTextableChannel>) {
   if (!msg.author || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot) {
     return // Message not cached; let's just ignore
   }
 
-  // todo: log attachments
   this.createMessage(config.discord.ids.channelMessageLogs, {
-    content: TEMPLATE
+    content: `${SINGLE_TEMPLATE
       .replace('$channelId', msg.channel.id)
       .replace('$username', msg.author.username.replace(/`/g, `\`${ZWS}`))
       .replace('$discrim', msg.author.discriminator)
       .replace(/\$userId/g, msg.author.id)
       .replace('$time', new Date(msg.timestamp).toUTCString())
       .replace('$duration', prettyPrintTimeSpan(Date.now() - msg.timestamp))
-      .replace('$message', stringifyDiscordMessage(msg).replace(/`/g, `\`${ZWS}`) || '*No contents*'),
+      .replace('$message', stringifyDiscordMessage(msg).replace(/`/g, `\`${ZWS}`) || '*No contents*')}${msg.attachments.length > 0 ?
+        `Attachments:\n\`${msg.attachments.map(attachment => attachment.filename).join('`, `')}\`` :
+        ''}`.trim(),
     allowedMentions: {}
   })
 }
 
+async function messageDeleteBulk(this: CommandClient, msgs: (Message<GuildTextableChannel> | MessagePartial)[]) {
+  let list = ''
+  msgs.forEach(msg => {
+    if ('author' in msg) {
+      list += `${LIST_TEMPLATE
+        .replace('$channel', msg.channel.name)
+        .replace('$username', msg.author.username.replace(/`/g, `\`${ZWS}`))
+        .replace('$userId', msg.author.id)
+        .replace('$discrim', msg.author.discriminator)
+        .replace('$time', new Date(msg.timestamp).toUTCString())
+        .replace('$duration', prettyPrintTimeSpan(Date.now() - msg.timestamp))
+        .replace('$message', stringifyDiscordMessage(msg).replace(/`/g, `\`${ZWS}`) || '*No contents*')}\n${msg.attachments.length > 0 ?
+          `Attachments:\n${msg.attachments.map(attachment => attachment.filename).join(', ')}` :
+          ''}\n\n`
+    } else {
+      list += `A message in #${msg.channel.name} that was not cached\n\n`
+    }
+  })
+
+  const res = await fetch('https://haste.powercord.dev/documents', { method: 'POST', body: list.trim() }).then(r => r.json())
+  this.createMessage(config.discord.ids.channelMessageLogs, `${msgs.length} messages deleted:\n<https://haste.powercord.dev/${res.key}.txt>`)
+}
+
 export default function (bot: CommandClient) {
-  bot.on('messageDelete', process)
+  bot.on('messageDelete', messageDelete)
+  bot.on('messageDeleteBulk', messageDeleteBulk)
 }


### PR DESCRIPTION
This PR adds an event listener to boat/src/modules/logger.ts to look for bulk message deletes. These usually happen when someone is banned. The list of deleted messages is uploaded to powercord.dev/hastebin as the content is usually over 2000 characters and its just nicer to look at imo. Also, attachment names are logged in both normal deletes and bulk deletes, getting rid of a `// todo:`.