### PR TITLE
fix: stringifyDiscordMessage replace callback

### DIFF
--- a/boat/src/util.ts
+++ b/boat/src/util.ts
@@ -75,9 +75,9 @@ export function prettyPrintTimeSpan (time: number) {
 export function stringifyDiscordMessage (message: Message<GuildTextableChannel>) {
   return message.content
     .replace(/<a?(:\w+:)[0-9]+>/g, '$1')
-    .replace(/<@!?([0-9]+)>/g, ([ , id ]) => `@${message.channel.guild.members.get(id)?.nick ?? message._client.users.get(id)?.username ?? 'invalid-user'}`)
-    .replace(/<@&([0-9]+)>/g, ([ , id ]) => `@${message.channel.guild.roles.get(id)?.name ?? 'invalid-role'}`)
-    .replace(/<#([0-9]+)>/g, ([ , id ]) => `@${message.channel.guild.channels.get(id)?.name ?? 'deleted-channel'}`)
+    .replace(/<@!?([0-9]+)>/g, (_, id ) => `@${message.channel.guild.members.get(id)?.nick ?? message._client.users.get(id)?.username ?? 'invalid-user'}`)
+    .replace(/<@&([0-9]+)>/g, (_, id ) => `@${message.channel.guild.roles.get(id)?.name ?? 'invalid-role'}`)
+    .replace(/<#([0-9]+)>/g, (_, id ) => `@${message.channel.guild.channels.get(id)?.name ?? 'deleted-channel'}`)
 }
 
 export function parseDuration (duration: string): number | null {

--- a/boat/src/util.ts
+++ b/boat/src/util.ts
@@ -77,7 +77,7 @@ export function stringifyDiscordMessage (message: Message<GuildTextableChannel>)
     .replace(/<a?(:\w+:)[0-9]+>/g, '$1')
     .replace(/<@!?([0-9]+)>/g, (_, id ) => `@${message.channel.guild.members.get(id)?.nick ?? message._client.users.get(id)?.username ?? 'invalid-user'}`)
     .replace(/<@&([0-9]+)>/g, (_, id ) => `@${message.channel.guild.roles.get(id)?.name ?? 'invalid-role'}`)
-    .replace(/<#([0-9]+)>/g, (_, id ) => `@${message.channel.guild.channels.get(id)?.name ?? 'deleted-channel'}`)
+    .replace(/<#([0-9]+)>/g, (_, id ) => `#${message.channel.guild.channels.get(id)?.name ?? 'deleted-channel'}`)
 }
 
 export function parseDuration (duration: string): number | null {

--- a/boat/src/util.ts
+++ b/boat/src/util.ts
@@ -75,9 +75,9 @@ export function prettyPrintTimeSpan (time: number) {
 export function stringifyDiscordMessage (message: Message<GuildTextableChannel>) {
   return message.content
     .replace(/<a?(:\w+:)[0-9]+>/g, '$1')
-    .replace(/<@!?([0-9]+)>/g, (_, id ) => `@${message.channel.guild.members.get(id)?.nick ?? message._client.users.get(id)?.username ?? 'invalid-user'}`)
-    .replace(/<@&([0-9]+)>/g, (_, id ) => `@${message.channel.guild.roles.get(id)?.name ?? 'invalid-role'}`)
-    .replace(/<#([0-9]+)>/g, (_, id ) => `#${message.channel.guild.channels.get(id)?.name ?? 'deleted-channel'}`)
+    .replace(/<@!?([0-9]+)>/g, (_, id) => `@${message.channel.guild.members.get(id)?.nick ?? message._client.users.get(id)?.username ?? 'invalid-user'}`)
+    .replace(/<@&([0-9]+)>/g, (_, id) => `@${message.channel.guild.roles.get(id)?.name ?? 'invalid-role'}`)
+    .replace(/<#([0-9]+)>/g, (_, id) => `#${message.channel.guild.channels.get(id)?.name ?? 'deleted-channel'}`)
 }
 
 export function parseDuration (duration: string): number | null {


### PR DESCRIPTION
the old method always had `id` be the second character in the full match which was never a full id. This way is just the numeric characters which is the id. Also channel names are now prefixed with `#` instead of `@`. 