### PR TITLE
[BOAT] snipe no longer sees blacklist deletes

### DIFF
--- a/boat/src/commands/mod/blacklist.ts
+++ b/boat/src/commands/mod/blacklist.ts
@@ -40,7 +40,7 @@ export async function executor (msg: Message<GuildTextableChannel>, args: string
 
   switch (args.shift()) {
     case 'show':
-      msg.channel.createMessage(getBlacklist().length > 0 ? getBlacklist().join(', ') : 'The blacklist has no entries.')
+      msg.channel.createMessage(getBlacklist().length > 0 ? `\`${getBlacklist().join('`, `')}\`` : 'The blacklist has no entries.')
       break
 
     case 'add':

--- a/boat/src/modules/sniper.ts
+++ b/boat/src/modules/sniper.ts
@@ -21,6 +21,7 @@
  */
 
 import type { CommandClient, Message, GuildTextableChannel, TextableChannel, TextChannel, OldMessage, User } from 'eris'
+import { getBlacklist } from '../blacklistCache.js'
 import config from '../config.js'
 
 // Thanks eris typings for sucking ass
@@ -35,6 +36,10 @@ const buffer = new Map<number, SnipeRecord>()
 
 function isPrivate (channel: TextChannel) {
   return Boolean((channel.permissionOverwrites.get(channel.guild.id)?.deny ?? 0) & 1024)
+}
+
+function containsBlacklist (content: string) : boolean {
+  return getBlacklist().some(word => content.toLowerCase().includes(word))
 }
 
 async function store (msg: MessageLike, type: 'edit' | 'delete') {
@@ -58,7 +63,7 @@ function processEdit (msg: Message<GuildTextableChannel>, old: OldMessage | null
 }
 
 function processDelete (msg: PossiblyUncachedMessage) {
-  if (!('author' in msg) || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot || isPrivate(msg.channel)) {
+  if (!('author' in msg) || msg.channel.guild.id !== config.discord.ids.serverId || msg.author.bot || isPrivate(msg.channel) || containsBlacklist(msg.content)) {
     return // Ignore
   }
 


### PR DESCRIPTION
You cant snipe messages that were deleted from the blacklist now. Also, the show subcommand uses backtick code formatting so its easier to read.