### PR TITLE
Add "tags" alias to tag command

### DIFF
--- a/packages/boat/src/commands/tag.ts
+++ b/packages/boat/src/commands/tag.ts
@@ -74,7 +74,7 @@ async function sendTag (msg: Message<GuildTextableChannel>, args: string[]): Pro
 }
 
 export const description = 'Custom commands'
-
+export const aliases = [ 'tags' ]
 export function executor (msg: Message<GuildTextableChannel>, args: string[]): void {
   if (!msg.member) return // ???
 


### PR DESCRIPTION
I always find myself typing "pc/tags" trying to view tags, so typing "pc/tags" even if it just returns the usage error would still be nice. 