### PR TITLE
[BOAT] Make manual mutes count towards rule -1

### DIFF
--- a/packages/boat/src/commands/mod/mute.ts
+++ b/packages/boat/src/commands/mod/mute.ts
@@ -64,5 +64,10 @@ export function executor (msg: Message<GuildTextableChannel>, args: string[]): v
 
   mute(msg.channel.guild, target, msg.author, reason, duration)
   msg.channel.createMessage('Shut')
+  msg._client.mongo.collection('enforce').insertOne({
+    userId: target,
+    modId: msg.author.id,
+    rule: -1,
+  })
   return
 }

--- a/packages/boat/src/modules/mod/mutedmod.ts
+++ b/packages/boat/src/modules/mod/mutedmod.ts
@@ -25,7 +25,6 @@ import { ban } from '../../mod.js'
 import { delayedFunction, extractEntryData } from '../../util.js'
 import config from '../../config.js'
 
-
 const MAX_INFRACTIONS = 4
 
 async function memberRemove (this: CommandClient, guild: Guild, member: Member | MemberPartial) {


### PR DESCRIPTION
This PR keeps track of mutes which are applied without the use of the enforce command. Mutes applied using the mute command and manual role management are included. They are stored in the `enforce` collection under rule `-1` just like muted leaves are.

*note: I had to change the tsconfig `target`, `lib`, and `module` keys to `es2020` to get the bot to run even before my changes. This change is not included in this PR as the existing `esnext` configuration may work fine on other systems