### PR TITLE
[BOAT] Use new timestamp mentions when possible

### DIFF
--- a/packages/boat/src/commands/mod/lookup.ts
+++ b/packages/boat/src/commands/mod/lookup.ts
@@ -42,7 +42,7 @@ export async function executor (msg: Message<GuildTextableChannel>, args: string
   const memberId = args.shift()!.replace(ID_REGEX, '$1')
   let member = msg.channel.guild.members.get(memberId)
   if (!member) {
-    const fetched = await await msg.channel.guild.fetchMembers({ userIDs: [ memberId ] })
+    const fetched = await msg.channel.guild.fetchMembers({ userIDs: [ memberId ] })
     member = fetched[0]
   }
 
@@ -61,12 +61,12 @@ export async function executor (msg: Message<GuildTextableChannel>, args: string
 
     if (infraction) {
       infractions[infractions.indexOf(infraction)].count++
-      infractions[infractions.indexOf(infraction)].occurrences.push(`• <t:${timestamp}> (<t:${timestamp}:R>)`)
+      infractions[infractions.indexOf(infraction)].occurrences.push(`• <t:${timestamp}>`)
     } else {
       infractions.push({
         rule: doc.rule,
         count: 1,
-        occurrences: [ `• <t:${timestamp}> (<t:${timestamp}:R>)` ],
+        occurrences: [ `• <t:${timestamp}>` ],
       })
     }
   })

--- a/packages/boat/src/modules/mod/logger.ts
+++ b/packages/boat/src/modules/mod/logger.ts
@@ -59,7 +59,7 @@ function format (template: string, message: Message<GuildTextableChannel>): stri
     .replace(/\$channel/g, message.channel.name)
     .replace(/\$username/g, sanitizeMarkdown(message.author.username))
     .replace(/\$discrim/g, message.author.discriminator)
-    .replace(/\$time/g, new Date(message.timestamp).toUTCString())
+    .replace(/\$time/g, `<t:${Math.floor(message.timestamp / 1000)}>`)
     .replace(/\$duration/g, prettyPrintTimeSpan(Date.now() - message.timestamp))
     .replace(/\$message/g, stringifyDiscordMessage(message).replace(/`/g, `\`${ZWS}`) || '*No contents*')}\n${attachments}`
 }

--- a/packages/boat/src/modules/mod/memberlog.ts
+++ b/packages/boat/src/modules/mod/memberlog.ts
@@ -29,14 +29,13 @@ type OldMember = { nick?: string; premiumSince: number; roles: string[] } | null
 function memberAdd (this: CommandClient, guild: Guild, member: Member) {
   if (guild.id !== config.discord.ids.serverId) return
 
-  const date = new Date(member.createdAt).toUTCString()
   const elapsed = prettyPrintTimeSpan(Date.now() - member.createdAt)
 
   this.createMessage(config.discord.ids.channelMemberLogs, {
     embed: {
       title: `${member.username}#${member.discriminator} just joined`,
       // there are no typo in the next line
-      description: `<@${member.id}> created their accout at ${date} (${elapsed})`,
+      description: `<@${member.id}> created their accout at <t${Math.floor(member.createdAt / 1000)}> (${elapsed})`,
       // there are no typo in the previous line
       timestamp: new Date().toISOString(),
       color: 0x7289da,

--- a/packages/boat/src/modules/mod/memberlog.ts
+++ b/packages/boat/src/modules/mod/memberlog.ts
@@ -35,7 +35,7 @@ function memberAdd (this: CommandClient, guild: Guild, member: Member) {
     embed: {
       title: `${member.username}#${member.discriminator} just joined`,
       // there are no typo in the next line
-      description: `<@${member.id}> created their accout at <t${Math.floor(member.createdAt / 1000)}> (${elapsed})`,
+      description: `<@${member.id}> created their accout at <t:${Math.floor(member.createdAt / 1000)}> (${elapsed} agp)`,
       // there are no typo in the previous line
       timestamp: new Date().toISOString(),
       color: 0x7289da,

--- a/packages/boat/src/modules/mod/memberlog.ts
+++ b/packages/boat/src/modules/mod/memberlog.ts
@@ -35,7 +35,7 @@ function memberAdd (this: CommandClient, guild: Guild, member: Member) {
     embed: {
       title: `${member.username}#${member.discriminator} just joined`,
       // there are no typo in the next line
-      description: `<@${member.id}> created their accout at <t:${Math.floor(member.createdAt / 1000)}> (${elapsed} agp)`,
+      description: `<@${member.id}> created their accout at <t:${Math.floor(member.createdAt / 1000)}> (${elapsed} ago)`,
       // there are no typo in the previous line
       timestamp: new Date().toISOString(),
       color: 0x7289da,


### PR DESCRIPTION
This PR makes use of timestamp mentions in the deleted log, member log, and lookup commands. 

*This is will be marked as a draft until this feature fully rolls out