### PR TITLE
[BOAT] Fix logger so bulk deletes and large message deletes still get logged

### DIFF
--- a/packages/boat/src/modules/mod/logger.ts
+++ b/packages/boat/src/modules/mod/logger.ts
@@ -50,7 +50,7 @@ Message contents:
 $message`
 
 async function format (template: string, message: Message<GuildTextableChannel>, bulk: boolean = false): Promise<string> {
-  const cleanContent = stringifyDiscordMessage(message)
+  const cleanContent = stringifyDiscordMessage(message).replace(/`/g, `\`${ZWS}`)
   let extra = ''
 
   if (!bulk && cleanContent.length > 1700) {
@@ -85,7 +85,7 @@ async function format (template: string, message: Message<GuildTextableChannel>,
     .replace(/\$duration/g, prettyPrintTimeSpan(Date.now() - message.timestamp))
     .replace(/\$message/g, !bulk && cleanContent.length > 1700
       ? '*Message too long*'
-      : cleanContent.replace(/`/g, `\`${ZWS}`)
+      : cleanContent
       || '*No contents*')}${extra}`
 }
 

--- a/packages/boat/src/modules/mod/logger.ts
+++ b/packages/boat/src/modules/mod/logger.ts
@@ -69,6 +69,10 @@ async function format (template: string, message: Message<GuildTextableChannel>,
     ? `\nReason: ${deleteMeta.get(message.id)}`
     : ''
 
+  const timestamp = bulk
+    ? new Date(message.timestamp).toUTCString()
+    : `<t:${Math.floor(message.timestamp / 1000)}>`
+
   deleteMeta.delete(message.id)
   return `${template
     .replace(/\$meta/g, meta)
@@ -77,7 +81,7 @@ async function format (template: string, message: Message<GuildTextableChannel>,
     .replace(/\$channel/g, message.channel.name)
     .replace(/\$username/g, sanitizeMarkdown(message.author.username))
     .replace(/\$discrim/g, message.author.discriminator)
-    .replace(/\$time/g, `<t:${Math.floor(message.timestamp / 1000)}>`)
+    .replace(/\$time/g, timestamp)
     .replace(/\$duration/g, prettyPrintTimeSpan(Date.now() - message.timestamp))
     .replace(/\$message/g, !bulk && cleanContent.length > 1700
       ? '*Message too long*'

--- a/packages/boat/src/modules/mod/logger.ts
+++ b/packages/boat/src/modules/mod/logger.ts
@@ -43,24 +43,24 @@ Message contents:
 $message`
 
 async function format (template: string, message: Message<GuildTextableChannel>): Promise<string> {
-  const cleanContent = stringifyDiscordMessage(message)
-  let extra = ''
-
-  if (cleanContent.length > 1700) {
-    const res = await fetch('https://haste.powercord.dev/documents', {
-      method: 'POST',
-      body: cleanContent,
-    }).then((r) => r.json())
-    extra += `<https://haste.powercord.dev/${res.key}.txt>\n\n`
-  }
-
-  if (message.attachments.length > 0) {
-    extra += `Attachments:\n${message.attachments.map((attachment) => attachment.filename).join(', ')}`
-  }
+  const attachments = message.attachments.length > 0
+    ? `Attachments:\n${message.attachments.map((attachment) => attachment.filename).join(', ')}`
+    : ''
 
   const meta = deleteMeta.has(message.id)
     ? `\nReason: ${deleteMeta.get(message.id)}`
     : ''
+
+  const tooLong = message.content.length > 1700
+  let hasteBin = ''
+
+  if (tooLong) {
+    const res = await fetch('https://haste.powercord.dev/documents', {
+      method: 'POST',
+      body: stringifyDiscordMessage(message),
+    }).then((r) => r.json())
+    hasteBin = `<https://haste.powercord.dev/${res.key}.txt>`
+  }
 
   deleteMeta.delete(message.id)
   return `${template
@@ -72,10 +72,10 @@ async function format (template: string, message: Message<GuildTextableChannel>)
     .replace(/\$discrim/g, message.author.discriminator)
     .replace(/\$time/g, new Date(message.timestamp).toUTCString())
     .replace(/\$duration/g, prettyPrintTimeSpan(Date.now() - message.timestamp))
-    .replace(/\$message/g, cleanContent.length > 1700
+    .replace(/\$message/g, tooLong
       ? '*Message too long*'
-      : cleanContent.replace(/`/g, `\`${ZWS}`)
-      || '*No contents*')}${extra}`
+      : stringifyDiscordMessage(message).replace(/`/g, `\`${ZWS}`)
+      || '*No contents*')}${hasteBin}\n${attachments}`
 }
 
 async function messageDelete (this: CommandClient, msg: Message<GuildTextableChannel>) {

--- a/packages/boat/src/modules/mod/logger.ts
+++ b/packages/boat/src/modules/mod/logger.ts
@@ -50,10 +50,11 @@ Message contents:
 $message`
 
 async function format (template: string, message: Message<GuildTextableChannel>, bulk: boolean = false): Promise<string> {
-  const cleanContent = stringifyDiscordMessage(message).replace(/`/g, `\`${ZWS}`)
+  const cleanContent = stringifyDiscordMessage(message)
+  const escapedContent = cleanContent.replace(/`/g, `\`${ZWS}`)
   let extra = ''
 
-  if (!bulk && cleanContent.length > 1700) {
+  if (!bulk && escapedContent.length > 1700) {
     const res = await fetch('https://haste.powercord.dev/documents', {
       method: 'POST',
       body: cleanContent,
@@ -83,9 +84,9 @@ async function format (template: string, message: Message<GuildTextableChannel>,
     .replace(/\$discrim/g, message.author.discriminator)
     .replace(/\$time/g, timestamp)
     .replace(/\$duration/g, prettyPrintTimeSpan(Date.now() - message.timestamp))
-    .replace(/\$message/g, !bulk && cleanContent.length > 1700
+    .replace(/\$message/g, !bulk && escapedContent.length > 1700
       ? '*Message too long*'
-      : cleanContent
+      : escapedContent
       || '*No contents*')}${extra}`
 }
 

--- a/packages/boat/src/modules/mod/logger.ts
+++ b/packages/boat/src/modules/mod/logger.ts
@@ -100,10 +100,10 @@ async function messageDeleteBulk (this: CommandClient, msgs: Array<Message<Guild
   if (msgs[0].channel.guild.id !== config.discord.ids.serverId) {
     return // Let's just ignore
   }
+  const channelName = this.guilds.get(config.discord.ids.serverId)?.channels.get(msgs[0].channel.id)?.name || msgs[0].channel.id
 
   const list = []
   for (const msg of msgs) {
-    const channelName = this.guilds.get(config.discord.ids.serverId)?.channels.get(msg.channel.id)?.name || msg.channel.id
     list.push('author' in msg
       ? await format(LIST_TEMPLATE, msg, true)
       : `A message in #${channelName} that was not cached`)

--- a/packages/boat/src/modules/mod/logger.ts
+++ b/packages/boat/src/modules/mod/logger.ts
@@ -76,7 +76,7 @@ async function messageDelete (this: CommandClient, msg: Message<GuildTextableCha
 }
 
 async function messageDeleteBulk (this: CommandClient, msgs: Array<Message<GuildTextableChannel> | MessagePartial>) {
-  if (msgs[0].channel.id !== config.discord.ids.serverId) {
+  if (msgs[0].channel.guild.id !== config.discord.ids.serverId) {
     return // Let's just ignore
   }
 


### PR DESCRIPTION
This PR fixes two bugs in the logger module.
1. The condition that checked if a bulk delete should be logged compared the first messages channel id to the guild id from the config <:pawa_knock_head:842001776819306526>. 
1. Messages longer than 1700 characters are now uploaded to hastebin.powercord.dev to ensure the message sent in the logs is under 2000 characters.