### PR TITLE
fix: use up-to-date support guild invite link

### DIFF
--- a/packages/web/src/constants.ts
+++ b/packages/web/src/constants.ts
@@ -83,7 +83,7 @@ export const Routes = {
   BACKOFFICE_EVENTS_SECRET: '/backoffice/events/secret',
 
   // External links
-  DICKSWORD: 'https://discord.gg/powercord',
+  DICKSWORD: 'https://discord.gg/gs4ZMbBfCh',
   PATREON: 'https://patreon.com/aetheryx',
   GITHUB: 'https://github.com/powercord-org',
 }


### PR DESCRIPTION
Uses the invite link from https://raw.githubusercontent.com/wiki/powercord-org/powercord/Frequently-Asked-Questions.md